### PR TITLE
[Fix] Fixes selection app with remote

### DIFF
--- a/app/src/main/java/nl/ncaj/tvlauncher/KeyEvents.kt
+++ b/app/src/main/java/nl/ncaj/tvlauncher/KeyEvents.kt
@@ -9,7 +9,7 @@ private val acceptKeys = listOf(
 )
 
 /**
- * Calls [onEnter] when the key pressed is of [Key.Enter]
+ * Calls [onEnter] when the key pressed is of one of [acceptKeys]
  * and the event is of [KeyEventType.KeyUp].
  *
  * @param onEnter the lambda that is called when the above criteria is met

--- a/app/src/main/java/nl/ncaj/tvlauncher/KeyEvents.kt
+++ b/app/src/main/java/nl/ncaj/tvlauncher/KeyEvents.kt
@@ -3,6 +3,11 @@ package nl.ncaj.tvlauncher
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.*
 
+private val acceptKeys = listOf(
+  Key.Enter,
+  Key.DirectionCenter
+)
+
 /**
  * Calls [onEnter] when the key pressed is of [Key.Enter]
  * and the event is of [KeyEventType.KeyUp].
@@ -12,7 +17,7 @@ import androidx.compose.ui.input.key.*
 fun Modifier.onEnterKeyEvent(
   onEnter: () -> Unit
 ) = this.onKeyEvent {
-  if (it.type == KeyEventType.KeyUp && it.key == Key.Enter) {
+  if (it.type == KeyEventType.KeyUp && acceptKeys.contains(it.key)) {
     onEnter()
     return@onKeyEvent true
   }


### PR DESCRIPTION
Before only `Key.Enter` was checked but some device remotes uses `Key.DirectionCenter`.